### PR TITLE
SafeConfigParser prevents string interpolation

### DIFF
--- a/pubweb/config.py
+++ b/pubweb/config.py
@@ -35,7 +35,7 @@ def get_config_path() -> Path:
 
 
 def save_config(auth_config: AuthConfig):
-    ini_config = configparser.ConfigParser()
+    ini_config = configparser.SafeConfigParser()
     ini_config['DEFAULT'] = auth_config.__dict__
     config_path = get_config_path()
     config_path.parent.mkdir(exist_ok=True)


### PR DESCRIPTION
This fixes the bug when a password has a `%` character