### PR TITLE
Disable auth cache by default if there is no config

### DIFF
--- a/cirro/api/auth/oauth_client.py
+++ b/cirro/api/auth/oauth_client.py
@@ -1,10 +1,10 @@
-from io import StringIO
 import json
 import logging
 import sys
 import threading
 import time
 from datetime import datetime, timedelta
+from io import StringIO
 from pathlib import Path
 from typing import Optional
 
@@ -92,7 +92,7 @@ class ClientAuth(AuthInfo):
         client_id: str,
         region: str,
         auth_endpoint: str,
-        enable_cache=True,
+        enable_cache=False,
         auth_io: Optional[StringIO] = None
     ):
         self.client_id = client_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cirro"
-version = "0.7.3"
+version = "0.7.4"
 description = "CLI tool and SDK for interacting with the Cirro platform"
 authors = ["Cirro Bio <support@cirro.bio>"]
 license = "MIT"


### PR DESCRIPTION
We ask the user if they want to do this when using the CLI, so no reason to do this be default when using the SDK.