### PR TITLE
Improve CLI upload / download experience

### DIFF
--- a/cirro/cli/controller.py
+++ b/cirro/cli/controller.py
@@ -56,10 +56,12 @@ def run_ingest(input_params: UploadArguments, interactive=False):
         return
 
     if interactive:
-        input_params = gather_upload_arguments(input_params, projects, processes)
+        input_params, files = gather_upload_arguments(input_params, projects, processes)
+        directory = input_params['data_directory']
+    else:
+        directory = input_params['data_directory']
+        files = get_files_in_directory(directory)
 
-    directory = input_params['data_directory']
-    files = get_files_in_directory(directory)
     if len(files) == 0:
         raise RuntimeWarning("No files to upload, exiting")
 

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -32,7 +32,17 @@ def ask_dataset(datasets: List[Dataset], input_value: str) -> str:
     for dataset in datasets:
         if f'{dataset.name} - {dataset.id}' == choice:
             return dataset.id
-    raise InputError("User must select a dataset to download")
+
+    # The user has made a selection which does not match
+    # any of the options available.
+    # This is most likely because there was a typo
+    if prompt_wrapper({
+        'type': 'confirm',
+        'name': 'try_again',
+        'message': 'The selection does match an option available - try again?'
+    })['try_again']:
+        return ask_dataset(datasets)
+    raise InputError("Exiting - no dataset selected")
 
 
 def ask_dataset_files(files: List[File]) -> List[File]:

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -68,7 +68,7 @@ def ask_dataset_files(files: List[File]) -> List[File]:
         return ask_dataset_files_list(files)
     else:
         return ask_dataset_files_glob(files)
-    
+
 
 def strip_prefix(fp: str, prefix: str):
     assert fp.startswith(prefix), f"Expected {fp} to start with {prefix}"

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -41,7 +41,7 @@ def ask_dataset(datasets: List[Dataset], input_value: str) -> str:
         'name': 'try_again',
         'message': 'The selection does match an option available - try again?'
     })['try_again']:
-        return ask_dataset(datasets)
+        return ask_dataset(datasets, input_value)
     raise InputError("Exiting - no dataset selected")
 
 

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -101,11 +101,7 @@ def ask_dataset_files_list(files: List[File]) -> List[File]:
 
 def ask_dataset_files_glob(files: List[File]) -> List[File]:
 
-    selected_files = ask_dataset_files_glob_single(files)
-    confirmed = ask(
-        "confirm",
-        f'Number of files selected: {len(selected_files):} / {len(files):,}'
-    )
+    confirmed = False
     while not confirmed:
         selected_files = ask_dataset_files_glob_single(files)
         confirmed = ask(

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -68,6 +68,11 @@ def ask_dataset_files(files: List[File]) -> List[File]:
         return ask_dataset_files_list(files)
     else:
         return ask_dataset_files_glob(files)
+    
+
+def strip_prefix(fp: str, prefix: str):
+    assert fp.startswith(prefix), f"Expected {fp} to start with {prefix}"
+    return fp[len(prefix):]
 
 
 def ask_dataset_files_list(files: List[File]) -> List[File]:
@@ -76,7 +81,7 @@ def ask_dataset_files_list(files: List[File]) -> List[File]:
         'name': 'files',
         'message': 'Select the files to download',
         'choices': [
-            file.relative_path
+            strip_prefix(file.relative_path, "data/")
             for file in files
         ]
     })
@@ -84,7 +89,7 @@ def ask_dataset_files_list(files: List[File]) -> List[File]:
     selected_files = [
         file
         for file in files
-        if file.relative_path in set(answers['files'])
+        if strip_prefix(file.relative_path, "data/") in set(answers['files'])
     ]
 
     if len(selected_files) == 0:
@@ -119,7 +124,7 @@ def ask_dataset_files_glob_single(files: List[File]) -> List[File]:
 
     print("All Files:")
     for file in files:
-        print(f" - {file.relative_path}")
+        print(f" - {strip_prefix(file.relative_path, 'data/')}")
 
     answers = prompt_wrapper({
         'type': 'text',
@@ -131,12 +136,12 @@ def ask_dataset_files_glob_single(files: List[File]) -> List[File]:
     selected_files = [
         file
         for file in files
-        if fnmatch(file.relative_path, answers['glob'])
+        if fnmatch(strip_prefix(file.relative_path, "data/"), answers['glob'])
     ]
 
     print("Selected Files:")
     for file in selected_files:
-        print(f" - {file.relative_path}")
+        print(f" - {strip_prefix(file.relative_path, 'data/')}")
 
     return selected_files
 

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -6,7 +6,7 @@ from cirro.api.models.dataset import Dataset
 from cirro.api.models.file import File
 from cirro.api.models.project import Project
 from cirro.cli.interactive.common_args import ask_project
-from cirro.cli.interactive.utils import prompt_wrapper, InputError
+from cirro.cli.interactive.utils import ask, prompt_wrapper, InputError
 from cirro.cli.models import DownloadArguments
 from cirro.utils import format_date
 
@@ -89,11 +89,10 @@ def ask_dataset_files_list(files: List[File]) -> List[File]:
     ]
 
     if len(selected_files) == 0:
-        if prompt_wrapper({
-            'type': 'confirm',
-            'name': 'try_again',
-            'message': 'No files were selected - try again?'
-        })['try_again']:
+        if ask(
+            "confirm",
+            "No files were selected - try again?"
+        ):
             return ask_dataset_files_list(files)
         else:
             raise RuntimeWarning("No files selected")

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -36,11 +36,10 @@ def ask_dataset(datasets: List[Dataset], input_value: str) -> str:
     # The user has made a selection which does not match
     # any of the options available.
     # This is most likely because there was a typo
-    if prompt_wrapper({
-        'type': 'confirm',
-        'name': 'try_again',
-        'message': 'The selection does match an option available - try again?'
-    })['try_again']:
+    if ask(
+        'confirm',
+        'The selection does match an option available - try again?'
+    ):
         return ask_dataset(datasets, input_value)
     raise InputError("Exiting - no dataset selected")
 
@@ -103,18 +102,16 @@ def ask_dataset_files_list(files: List[File]) -> List[File]:
 def ask_dataset_files_glob(files: List[File]) -> List[File]:
 
     selected_files = ask_dataset_files_glob_single(files)
-    answers = prompt_wrapper({
-        'type': 'confirm',
-        'name': 'confirm',
-        'message': f'Number of files selected: {len(selected_files):} / {len(files):,}'
-    })
-    while not answers['confirm']:
+    confirmed = ask(
+        "confirm",
+        f'Number of files selected: {len(selected_files):} / {len(files):,}'
+    )
+    while not confirmed:
         selected_files = ask_dataset_files_glob_single(files)
-        answers = prompt_wrapper({
-            'type': 'confirm',
-            'name': 'confirm',
-            'message': f'Number of files selected: {len(selected_files):} / {len(files):,}'
-        })
+        confirmed = ask(
+            "confirm",
+            f'Number of files selected: {len(selected_files):} / {len(files):,}'
+        )
 
     if len(selected_files) == 0:
         raise RuntimeWarning("No files selected")

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -82,11 +82,23 @@ def ask_dataset_files_list(files: List[File]) -> List[File]:
         ]
     })
 
-    return [
+    selected_files = [
         file
         for file in files
         if file.relative_path in set(answers['files'])
     ]
+
+    if len(selected_files) == 0:
+        if prompt_wrapper({
+            'type': 'confirm',
+            'name': 'try_again',
+            'message': 'No files were selected - try again?'
+        })['try_again']:
+            return ask_dataset_files_list(files)
+        else:
+            raise RuntimeWarning("No files selected")
+    else:
+        return selected_files
 
 
 def ask_dataset_files_glob(files: List[File]) -> List[File]:
@@ -104,6 +116,10 @@ def ask_dataset_files_glob(files: List[File]) -> List[File]:
             'name': 'confirm',
             'message': f'Number of files selected: {len(selected_files):} / {len(files):,}'
         })
+
+    if len(selected_files) == 0:
+        raise RuntimeWarning("No files selected")
+
     return selected_files
 
 

--- a/cirro/cli/interactive/upload_args.py
+++ b/cirro/cli/interactive/upload_args.py
@@ -69,14 +69,11 @@ def confirm_data_files(data_directory: str, files: List[str]):
         Path(data_directory) / file
         for file in files
     ])
-    answers = prompt_wrapper({
-        'type': 'confirm',
-        'message': f'Please confirm that you wish to upload {stats["numberOfFiles"]} files ({stats["sizeFriendly"]})',
-        'name': 'continue',
-        'default': True
-    })
 
-    if not answers['continue']:
+    if not ask(
+        "confirm",
+        f'Please confirm that you wish to upload {stats["numberOfFiles"]} files ({stats["sizeFriendly"]})'
+    ):
         sys.exit(1)
 
 
@@ -147,18 +144,20 @@ def ask_dataset_files_list(files: List[str]) -> List[str]:
 def ask_dataset_files_glob(files: List[str]) -> List[str]:
 
     selected_files = ask_dataset_files_glob_single(files)
-    answers = prompt_wrapper({
-        'type': 'confirm',
-        'name': 'confirm',
-        'message': f'Number of files selected: {len(selected_files):} / {len(files):,}'
-    })
-    while not answers['confirm']:
+    confirmed = ask(
+        "confirm",
+        f'Number of files selected: {len(selected_files):} / {len(files):,}'
+    )
+    while not confirmed:
         selected_files = ask_dataset_files_glob_single(files)
-        answers = prompt_wrapper({
-            'type': 'confirm',
-            'name': 'confirm',
-            'message': f'Number of files selected: {len(selected_files):} / {len(files):,}'
-        })
+        confirmed = ask(
+            "confirm",
+            f'Number of files selected: {len(selected_files):} / {len(files):,}'
+        )
+
+    if len(selected_files) == 0:
+        raise RuntimeWarning("No files selected")
+
     return selected_files
 
 

--- a/cirro/cli/interactive/upload_args.py
+++ b/cirro/cli/interactive/upload_args.py
@@ -2,11 +2,9 @@ import sys
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import List
-from fnmatch import fnmatch
 
 from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.validation import Validator, ValidationError
-from questionary import Choice
 
 from cirro.api.models.process import Process
 from cirro.api.models.project import Project
@@ -14,6 +12,46 @@ from cirro.cli.interactive.common_args import ask_project
 from cirro.cli.interactive.utils import ask, prompt_wrapper
 from cirro.cli.models import UploadArguments
 from cirro.file_utils import get_files_in_directory, get_files_stats
+
+
+def ask_data_directory(input_value: str) -> str:
+    directory_prompt = {
+        'type': 'path',
+        'name': 'data_directory',
+        'message': 'Enter the full path of the data directory',
+        'validate': DataDirectoryValidator,
+        'default': input_value or '',
+        'complete_style': CompleteStyle.READLINE_LIKE,
+        'only_directories': True
+    }
+
+    answers = prompt_wrapper(directory_prompt)
+    return answers['data_directory']
+
+
+def ask_name(input_value: str) -> str:
+    name_prompt = {
+        'type': 'input',
+        'name': 'name',
+        'message': 'What is the name of this dataset?',
+        'validate': lambda val: len(val.strip()) > 0 or 'Please enter a name',
+        'default': input_value or ''
+    }
+
+    answers = prompt_wrapper(name_prompt)
+    return answers['name']
+
+
+def ask_description(input_value: str) -> str:
+    description_prompt = {
+        'type': 'input',
+        'name': 'description',
+        'message': 'Enter a description of the dataset (optional)',
+        'default': input_value or ''
+    }
+
+    answers = prompt_wrapper(description_prompt)
+    return answers['description']
 
 
 class DataDirectoryValidator(Validator):

--- a/cirro/cli/interactive/upload_args.py
+++ b/cirro/cli/interactive/upload_args.py
@@ -115,18 +115,15 @@ def ask_files_in_directory(data_directory) -> List[str]:
         "Select files with a naming pattern (glob)"
     ]
 
-    selection_mode_prompt = {
-        'type': 'select',
-        'name': 'mode',
-        'message': 'Which files would you like to upload from this dataset?',
-        'choices': choices
-    }
+    choice = ask(
+        'select',
+        'Which files would you like to upload from this dataset?',
+        choices=choices
+    )
 
-    answers = prompt_wrapper(selection_mode_prompt)
-
-    if answers['mode'] == choices[0]:
+    if choice == choices[0]:
         return files
-    elif answers['mode'] == choices[1]:
+    elif choice == choices[1]:
         return ask_dataset_files_list(files)
     else:
         return ask_dataset_files_glob(files)

--- a/cirro/file_utils.py
+++ b/cirro/file_utils.py
@@ -67,11 +67,12 @@ def get_files_in_directory(
         str_file_path = str_file_path.replace(f'{path_posix}/', "")
         paths.append(str_file_path)
 
+    paths.sort()
     return paths
 
 
-def get_directory_stats(directory) -> DirectoryStatistics:
-    sizes = [f.stat().st_size for f in Path(directory).glob('**/*') if f.is_file()]
+def get_files_stats(files: List[File]) -> DirectoryStatistics:
+    sizes = [f.stat().st_size for f in files]
     total_size = sum(sizes) / float(1 << 30)
     return {
         'sizeFriendly': f'{total_size:,.3f} GB',

--- a/cirro/file_utils.py
+++ b/cirro/file_utils.py
@@ -39,7 +39,17 @@ def _is_hidden_file(file_path: Path):
         return file_path.name.startswith('.')
 
 
-def get_files_in_directory(directory) -> List[str]:
+def get_files_in_directory(
+    directory,
+    include_hidden=False
+) -> List[str]:
+    """
+    Returns a list of strings containing the relative path of
+    each file within the indicated directory.
+
+    include_hidden: bool
+        Include hidden files in the returned list
+    """
     path = Path(directory)
     path_posix = str(path.as_posix())
 
@@ -49,8 +59,9 @@ def get_files_in_directory(directory) -> List[str]:
         if file_path.is_dir():
             continue
 
-        if _is_hidden_file(file_path):
-            continue
+        if not include_hidden:
+            if _is_hidden_file(file_path):
+                continue
 
         str_file_path = str(file_path.as_posix())
         str_file_path = str_file_path.replace(f'{path_posix}/', "")

--- a/cirro/sdk/project.py
+++ b/cirro/sdk/project.py
@@ -134,6 +134,9 @@ class DataPortalProject(DataPortalAsset):
             # Get the list of files in the upload folder
             files = get_files_in_directory(upload_folder)
 
+        if files is None or len(files) == 0:
+            raise RuntimeWarning("No files to upload, exiting")
+
         # Make sure that the files match the expected pattern
         self._client.process.check_dataset_files(files, process.id, upload_folder)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cirro"
-version = "0.7.4"
+version = "0.8.0"
 description = "CLI tool and SDK for interacting with the Cirro platform"
 authors = ["Cirro Bio <support@cirro.bio>"]
 license = "MIT"


### PR DESCRIPTION
Features added:

- Let the user select a subset of files to upload by list or glob
- Prompt the user to try again if no files were selected for download / upload
- Prompt the user to try again if the dataset was not selected correctly (if they forget to hit the tab key)
- Let the user upload hidden files