### PR TITLE
cirro-cli configure bugfix - enable_additional_checksum

### DIFF
--- a/cirro/cli/controller.py
+++ b/cirro/cli/controller.py
@@ -171,11 +171,12 @@ def run_configure_workflow():
 
 
 def run_configure():
-    auth_method, auth_method_config = gather_auth_config()
+    auth_method, auth_method_config, enable_additional_checksum = gather_auth_config()
     save_user_config(UserConfig(auth_method=auth_method,
                                 auth_method_config=auth_method_config,
                                 base_url=None,
-                                transfer_max_retries=None))
+                                transfer_max_retries=None,
+                                enable_additional_checksum=enable_additional_checksum))
 
 
 def _check_configure():

--- a/cirro/cli/interactive/auth_args.py
+++ b/cirro/cli/interactive/auth_args.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Dict
 
-from cirro.cli.interactive.utils import ask_yes_no
+from cirro.cli.interactive.utils import ask_yes_no, ask
 
 
 def gather_auth_config() -> Tuple[str, Dict]:
@@ -8,4 +8,10 @@ def gather_auth_config() -> Tuple[str, Dict]:
         'enable_cache': ask_yes_no("Would you like to save your login? (do not use this on shared devices)")
     }
 
-    return 'ClientAuth', auth_method_config
+    enable_additional_checksum = ask(
+        "select",
+        "Upload / download validation type (note: SHA-256 requires additional local compute)",
+        choices=["MD5", "SHA-256"]
+    ) == "SHA-256"
+
+    return 'ClientAuth', auth_method_config, enable_additional_checksum


### PR DESCRIPTION
This patches a bug encountered when using `cirro-cli configure` to account for the new `enable_additional_checksum` element.