### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install deps
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install poetry
           poetry install --all-extras
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install deps
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Install deps
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install deps
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install poetry
 
       - name: Test install

--- a/cirro/api/clients/api.py
+++ b/cirro/api/clients/api.py
@@ -1,7 +1,7 @@
+import importlib.metadata
 import platform
 from typing import Dict
 
-import pkg_resources
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
@@ -9,8 +9,8 @@ from cirro.api.auth.base import AuthInfo
 from cirro.api.auth.iam import IAMAuth
 
 try:
-    sdk_version = pkg_resources.get_distribution("cirro").version
-except (pkg_resources.RequirementParseError, TypeError):
+    sdk_version = importlib.metadata.version('cirro')
+except (importlib.metadata.PackageNotFoundError, ValueError):
     sdk_version = "Unknown"
 python_version = platform.python_version()
 headers = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cirro"
-version = "0.8.1"
+version = "0.8.2"
 description = "CLI tool and SDK for interacting with the Cirro platform"
 authors = ["Cirro Bio <support@cirro.bio>"]
 license = "MIT"


### PR DESCRIPTION
- Remove deprecated usage of `pkg_resources`
- Also run tests on all supported versions