### PR TITLE
Fix when config is not present

### DIFF
--- a/cirro/api/config.py
+++ b/cirro/api/config.py
@@ -78,7 +78,8 @@ class AppConfig:
                          Constants.default_base_url)
         self.transfer_max_retries = self.user_config.transfer_max_retries\
             if self.user_config else Constants.default_max_retries
-        self.enable_additional_checksum = self.user_config.enable_additional_checksum or False
+        self.enable_additional_checksum = self.user_config.enable_additional_checksum\
+            if self.user_config else False
         self._init_config()
 
     def _init_config(self):

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1,0 +1,10 @@
+import unittest
+
+from cirro.api.config import AppConfig
+
+
+class TestConfigLoad(unittest.TestCase):
+    def test_config_load(self):
+        config = AppConfig()
+        self.assertIsNotNone(config.client_id)
+        self.assertIsNotNone(config.auth_endpoint)


### PR DESCRIPTION
Safe load the `enable_additional_checksum` property