### PR TITLE
Remove deprecated usage of ConfigParser

### DIFF
--- a/cirro/api/config.py
+++ b/cirro/api/config.py
@@ -24,7 +24,7 @@ class UserConfig(NamedTuple):
 
 def save_user_config(user_config: UserConfig):
     original_user_config = load_user_config()
-    ini_config = configparser.SafeConfigParser()
+    ini_config = configparser.ConfigParser()
     ini_config['General'] = {
         'auth_method': user_config.auth_method,
         'base_url': Constants.default_base_url,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cirro"
-version = "0.8.3"
+version = "0.8.4"
 description = "CLI tool and SDK for interacting with the Cirro platform"
 authors = ["Cirro Bio <support@cirro.bio>"]
 license = "MIT"


### PR DESCRIPTION
SafeConfigParser was removed in Python 3.12