### PR TITLE
Add advanced usage docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: pdoc build and deploy
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install poetry pdoc
+          poetry install --all-extras
+
+      - run: python make_docs.py
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 .vscode/settings.json
+docs/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ See the following set of Jupyter notebooks that contain examples on the followin
 | [Interacting with a dataset](samples/Interacting_with_files.ipynb) | Calling data and reading into tables |
 | [Analyzing a dataset](samples/Analyzing_a_dataset.ipynb)           | Running analysis pipelines           |
 | [Using references](samples/Using_references.ipynb)                 | Managing reference data              |
+| [Advanced usage](samples/Advanced_usage.ipynb)                     | Advanced operations                  |
 
 ## R Usage
 

--- a/cirro/__init__.py
+++ b/cirro/__init__.py
@@ -1,5 +1,7 @@
-from cirro.sdk import DataPortal
+from cirro.cirro_client import Cirro
+from cirro.sdk.portal import DataPortal
 
 __all__ = [
-    'DataPortal'
+    'DataPortal',
+    'Cirro'
 ]

--- a/cirro/auth/__init__.py
+++ b/cirro/auth/__init__.py
@@ -4,7 +4,8 @@ from typing import Optional
 from cirro.auth.device_code import DeviceCodeAuth
 
 __all__ = [
-    'get_auth_info_from_config'
+    'get_auth_info_from_config',
+    "DeviceCodeAuth"
 ]
 
 from cirro.config import AppConfig

--- a/cirro/clients/s3.py
+++ b/cirro/clients/s3.py
@@ -1,4 +1,3 @@
-import math
 import threading
 from pathlib import Path
 from typing import Callable
@@ -10,15 +9,7 @@ from botocore.session import get_session
 from cirro_api_client.v1.models import AWSCredentials
 from tqdm import tqdm
 
-
-def convert_size(size):
-    if size == 0:
-        return '0B'
-    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
-    i = int(math.floor(math.log(size, 1024)))
-    p = math.pow(1024, i)
-    s = round(size/p, 2)
-    return '%.2f %s' % (s, size_name[i])
+from cirro.utils import convert_size
 
 
 def format_creds_for_session(creds: AWSCredentials):

--- a/cirro/sdk/__init__.py
+++ b/cirro/sdk/__init__.py
@@ -1,5 +1,0 @@
-from cirro.sdk.portal import DataPortal
-
-__all__ = [
-    'DataPortal',
-]

--- a/cirro/sdk/asset.py
+++ b/cirro/sdk/asset.py
@@ -14,7 +14,7 @@ class DataPortalAsset:
         pass
 
     def __repr__(self):
-        return f'<{self.__class__.__name__}:name={self.name}>'
+        return f'{self.__class__.__name__}(name={self.name})'
 
 
 T = TypeVar('T', bound=DataPortalAsset)

--- a/cirro/sdk/dataset.py
+++ b/cirro/sdk/dataset.py
@@ -141,7 +141,7 @@ class DataPortalDataset(DataPortalAsset):
         # If the process is a string, try to parse it as a process name or ID
         process = parse_process_name_or_id(process, self._client)
 
-        return self._client.execution.run_analysis(
+        resp = self._client.execution.run_analysis(
             project_id=self.project_id,
             request=RunAnalysisRequest(
                 name=name,
@@ -152,6 +152,7 @@ class DataPortalDataset(DataPortalAsset):
                 notification_emails=notifications_emails
             )
         )
+        return resp.id
 
 
 class DataPortalDatasets(DataPortalAssets[DataPortalDataset]):

--- a/cirro/sdk/file.py
+++ b/cirro/sdk/file.py
@@ -4,10 +4,10 @@ from io import BytesIO, StringIO
 import pandas as pd
 
 from cirro.cirro_client import Cirro
-from cirro.clients.s3 import convert_size
 from cirro.models.file import File
 from cirro.sdk.asset import DataPortalAssets, DataPortalAsset
 from cirro.sdk.exceptions import DataPortalInputError
+from cirro.utils import convert_size
 
 
 class DataPortalFile(DataPortalAsset):

--- a/cirro/sdk/file.py
+++ b/cirro/sdk/file.py
@@ -4,6 +4,7 @@ from io import BytesIO, StringIO
 import pandas as pd
 
 from cirro.cirro_client import Cirro
+from cirro.clients.s3 import convert_size
 from cirro.models.file import File
 from cirro.sdk.asset import DataPortalAssets, DataPortalAsset
 from cirro.sdk.exceptions import DataPortalInputError
@@ -42,11 +43,19 @@ class DataPortalFile(DataPortalAsset):
         return self._file.metadata
 
     @property
-    def size(self):
+    def size_bytes(self):
         """
         File size (in bytes)
         """
         return self._file.size
+
+    @property
+    def size(self):
+        """
+        File size converted to human-readable
+        (e.g., 4.50 GB)
+        """
+        return convert_size(self._file.size)
 
     def __str__(self):
         return f"{self.relative_path} ({self.size} bytes)"

--- a/cirro/sdk/file.py
+++ b/cirro/sdk/file.py
@@ -58,7 +58,7 @@ class DataPortalFile(DataPortalAsset):
         return convert_size(self._file.size)
 
     def __str__(self):
-        return f"{self.relative_path} ({self.size} bytes)"
+        return f"{self.relative_path} ({self.size})"
 
     def _get(self) -> bytes:
         """Internal method to call client.file.get_file"""

--- a/cirro/sdk/file.py
+++ b/cirro/sdk/file.py
@@ -28,6 +28,10 @@ class DataPortalFile(DataPortalAsset):
 
     @property
     def name(self):
+        return self._file.relative_path
+
+    @property
+    def file_name(self):
         return self._file.name
 
     @property

--- a/cirro/services/dataset.py
+++ b/cirro/services/dataset.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Union
 
 from cirro_api_client.v1.api.datasets import get_datasets, get_dataset, import_public_dataset, upload_dataset, \
@@ -9,18 +8,19 @@ from cirro.models.file import FileAccessContext, File
 from cirro.services.base import get_all_records
 from cirro.services.file import FileEnabledService
 
-logger = logging.getLogger()
-
 
 class DatasetService(FileEnabledService):
     def list(self, project_id: str, max_items: int = 10000) -> List[Dataset]:
         """List datasets
 
-         Retrieves a list of datasets for a given project
+        Retrieves a list of datasets for a given project
 
         Args:
             project_id (str): ID of the Project
             max_items (int): Maximum number of records to get (default 10,000)
+
+        Returns:
+            `List[cirro_api_client.v1.models.Dataset]`
         """
         return get_all_records(
             records_getter=lambda page_args: get_datasets.sync(project_id=project_id,
@@ -33,6 +33,13 @@ class DatasetService(FileEnabledService):
     def import_public(self, project_id: str, import_request: ImportDataRequest):
         """
         Download data from public repositories
+
+        Args:
+            project_id (str): ID of the Project
+            import_request (cirro_api_client.v1.models.ImportDataRequest):
+
+        Returns:
+            `cirro_api_client.v1.models.CreateResponse`
         """
         return import_public_dataset.sync(project_id=project_id, client=self._api_client, body=import_request)
 

--- a/cirro/services/execution.py
+++ b/cirro/services/execution.py
@@ -25,15 +25,16 @@ class ExecutionService(BaseService):
 
     def get_project_summary(self, project_id: str):
         """
-        Gets an overview of the executions currently running in the project
+        Gets an overview of the executions currently running in the project, by job queue
         """
-        return get_project_summary.sync(project_id=project_id, client=self._api_client)
+        return get_project_summary.sync(project_id=project_id, client=self._api_client).additional_properties
 
     def get_execution_logs(self, project_id: str, dataset_id: str):
         """
         Gets live logs from main execution task
         """
-        return get_execution_logs.sync(project_id=project_id, dataset_id=dataset_id, client=self._api_client)
+        resp = get_execution_logs.sync(project_id=project_id, dataset_id=dataset_id, client=self._api_client)
+        return '\n'.join(e.message for e in resp.events)
 
     def get_tasks_for_execution(self, project_id: str, dataset_id: str):
         """
@@ -45,5 +46,6 @@ class ExecutionService(BaseService):
         """
         Gets the log output from an individual task
         """
-        return get_task_logs.sync(project_id=project_id, dataset_id=dataset_id,
+        resp = get_task_logs.sync(project_id=project_id, dataset_id=dataset_id,
                                   task_id=task_id, client=self._api_client)
+        return '\n'.join(e.message for e in resp.events)

--- a/cirro/services/projects.py
+++ b/cirro/services/projects.py
@@ -3,7 +3,7 @@ from typing import List
 
 from cirro_api_client.v1.api.projects import get_projects, create_project, get_project, set_user_project_role, \
     update_project, update_project_tags, get_project_users
-from cirro_api_client.v1.models import ProjectRequest, SetUserProjectRoleRequest, Tag
+from cirro_api_client.v1.models import ProjectRequest, SetUserProjectRoleRequest, Tag, ProjectRole
 
 from cirro.services.base import BaseService
 
@@ -47,8 +47,14 @@ class ProjectService(BaseService):
         """
         return get_project_users.sync(project_id=project_id, client=self._api_client)
 
-    def set_user_role(self, project_id: str, request: SetUserProjectRoleRequest):
+    def set_user_role(self, project_id: str, username: str, role: ProjectRole, supress_notification=False):
         """
-        Sets a user's role within a project
+        Sets a user's role within a project.
+        Set to ProjectRole.NONE if removing the user from a project
         """
-        set_user_project_role.sync_detailed(project_id=project_id, body=request, client=self._api_client)
+        request_body = SetUserProjectRoleRequest(
+            username=username,
+            role=role,
+            supress_notification=supress_notification
+        )
+        set_user_project_role.sync_detailed(project_id=project_id, body=request_body, client=self._api_client)

--- a/cirro/services/projects.py
+++ b/cirro/services/projects.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List
 
 from cirro_api_client.v1.api.projects import get_projects, create_project, get_project, set_user_project_role, \
@@ -6,8 +5,6 @@ from cirro_api_client.v1.api.projects import get_projects, create_project, get_p
 from cirro_api_client.v1.models import ProjectRequest, SetUserProjectRoleRequest, Tag, ProjectRole
 
 from cirro.services.base import BaseService
-
-logger = logging.getLogger()
 
 
 class ProjectService(BaseService):

--- a/cirro/utils.py
+++ b/cirro/utils.py
@@ -1,4 +1,5 @@
 import json
+import math
 from datetime import timezone, datetime
 from typing import Optional, Union
 
@@ -40,3 +41,13 @@ def print_credentials(creds: AWSCredentials):
     if creds.expiration:
         print()
         print(f'These credentials expire at {format_date(creds.expiration)}')
+
+
+def convert_size(size: int):
+    if size == 0:
+        return '0B'
+    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+    i = int(math.floor(math.log(size, 1024)))
+    p = math.pow(1024, i)
+    s = round(size/p, 2)
+    return '%.2f %s' % (s, size_name[i])

--- a/make_docs.py
+++ b/make_docs.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pdoc.render
+
+if __name__ == "__main__":
+    pdoc.render.configure(
+        docformat="google",
+        logo="https://static.cirro.bio/Cirro_Logo_Horizontal_Navy.png",
+        logo_link="https://cirro.bio",
+    )
+
+    pdoc.pdoc(
+        "cirro",
+        "cirro.sdk",
+        "cirro.auth",
+        "cirro.services",
+        "cirro_api_client",
+        "cirro_api_client.cirro_client",
+        "cirro_api_client.cirro_auth",
+        "cirro_api_client.v1.api",
+        "cirro_api_client.v1.client",
+        "cirro_api_client.v1.models",
+        output_directory=Path("./docs/")
+    )
+
+    # Redirect index.html to cirro.html since we want to expose that module first
+    with Path('./docs/index.html').open('w') as index:
+        index.write('<meta http-equiv="refresh" content="0; URL=cirro.html" />')

--- a/samples/Advanced_usage.ipynb
+++ b/samples/Advanced_usage.ipynb
@@ -1,0 +1,359 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Advanced Usage\n",
+    "\n",
+    "For operations that are not exposed by the `DataPortal` class, you must use the service layer directly.\n",
+    "This can be instantiated with the `Cirro` class. "
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "3698989ec61e0b3a"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "from cirro.cirro_client import Cirro\n",
+    "\n",
+    "cirro = Cirro()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-21T15:32:23.904125900Z",
+     "start_time": "2024-02-21T15:32:17.745106400Z"
+    }
+   },
+   "id": "f898e7caa5948296",
+   "execution_count": 2
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The services are exposed and separated out by each section. Look at the autocomplete options, or inspect the [cirro_client.py](../cirro/cirro_client.py) file."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "70cc9b8bc1519f38"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Examples"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "f533ad6d7bbdc87f"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "# Project / dataset used for the examples\n",
+    "test_project = cirro.projects.list()[-1]\n",
+    "dataset_id = '<dataset_id>'"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-21T15:40:02.411779700Z",
+     "start_time": "2024-02-21T15:39:59.628564100Z"
+    }
+   },
+   "id": "cdff373e4d67de2b",
+   "execution_count": 5
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "##### Adding a user to a project"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "d584ee62076d7e20"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "from cirro_api_client.v1.models import SetUserProjectRoleRequest, ProjectRole\n",
+    "\n",
+    "set_role_request = SetUserProjectRoleRequest(\n",
+    "    username='cirro@cirro.bio',\n",
+    "    role=ProjectRole.COLLABORATOR\n",
+    ")\n",
+    "cirro.projects.set_user_role(project_id=test_project.id,\n",
+    "                             request=set_role_request)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-21T04:54:22.791221200Z",
+     "start_time": "2024-02-21T04:54:22.097294300Z"
+    }
+   },
+   "id": "44f39568654ff898",
+   "execution_count": 14
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "##### Retrieving a list of running tasks for an analysis"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "35514c11906fcd03"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Task Name: extractStats\n",
+      "Status: COMPLETED\n",
+      "Stopped At: 2024-02-16T02:49:08.916000+00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "tasks = cirro.execution.get_tasks_for_execution(project_id=test_project.id,\n",
+    "                                                dataset_id=dataset_id)\n",
+    "\n",
+    "print(f'Task Name: {tasks[0].name}')\n",
+    "print(f'Status: {tasks[0].status}')\n",
+    "print(f'Stopped At: {tasks[0].stopped_at.isoformat()}')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-21T05:00:56.547489700Z",
+     "start_time": "2024-02-21T05:00:56.315723100Z"
+    }
+   },
+   "id": "39bdd000ccf5504a",
+   "execution_count": 3
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "##### Retrieving the log output of a task"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "99261a37a1f57017"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing lane 1\n",
+      "Processing tile 1101\n",
+      "Processing cycle 0\n",
+      "Processing cycle 1\n",
+      "Processing cycle 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "logs = cirro.execution.get_task_logs(project_id=test_project.id,\n",
+    "                                     dataset_id=dataset_id,\n",
+    "                                     task_id=tasks[0].native_job_id)\n",
+    "# Print first 5 lines of log output\n",
+    "print('\\n'.join(logs.splitlines()[0:5]))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-21T05:02:26.550772200Z",
+     "start_time": "2024-02-21T05:02:26.173178Z"
+    }
+   },
+   "id": "cc81f88d6d8687ec",
+   "execution_count": 9
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "##### Listing the jobs that are currently running in a project"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "ed9f6ea55fc5b6d7"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'Cirro-Spot-11a0fa10': [],\n 'Cirro-Head-11a0fa10': [],\n 'Cirro-OnDemand-11a0fa10': [],\n 'Cirro-Dragen-11a0fa10': []}"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cirro.execution.get_project_summary(project_id=test_project.id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-21T05:03:43.552292100Z",
+     "start_time": "2024-02-21T05:03:41.936410900Z"
+    }
+   },
+   "id": "6404a781457cb676",
+   "execution_count": 3
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "##### Retrieving the costs for a project"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "72b3a5ce2a4300cb"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Date: 2024-02-01\n",
+      "Services: {'Other': 4.96, 'EC2 - Other': 0.01, 'Amazon Elastic Compute Cloud - Compute': 0.06, 'Amazon SageMaker': 0.01, 'Amazon Simple Storage Service': 0.09, 'AmazonCloudWatch': 0.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "metrics = cirro.metrics.get_for_project(project_id=test_project.id)\n",
+    "latest_cost = metrics.costs[-1]\n",
+    "print(f'Date: {latest_cost.date}')\n",
+    "print(f'Services: {latest_cost.services.additional_properties}')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-21T05:06:14.236630400Z",
+     "start_time": "2024-02-21T05:06:14.066244800Z"
+    }
+   },
+   "id": "55ec56b49ae2bc07",
+   "execution_count": 11
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Lower-level API Client"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "77cff4056e6ad757"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "If you need to call certain endpoints that are not exposed by the SDK, use the lower-level API Client.\n",
+    "You can access the client by using the `api_client` property on the `Cirro` class.\n",
+    "\n",
+    "\n",
+    "The API client mirrors the [OpenAPI specification](https://api.dev.cirro.bio/openapi/views/redoc/index.html) of Cirro. It exposes every API endpoint under the syntax: `cirro_api_client.v1.api.<tag> import <endpoint>`. Models are exposed at `cirro_api_client\n",
+    "Each `tag` corresponds to a group of endpoints, such as datasets, metadata, projects, etc., and the `endpoint` corresponds to an operation.\n",
+    "\n",
+    "You can read more about the API client [here](https://github.com/CirroBio/Cirro-client-python). \n",
+    "\n",
+    "Each endpoint exposes a synchronous (`sync`) and asynchronous (`async`) function depending on if you use the async features in Python. All functions require the `client` parameter. You can pass in the `cirro.api_client` property here."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "7c395c1a541c36e7"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "from cirro_api_client.v1.api.datasets import rerun_transform\n",
+    "\n",
+    "rerun_transform.sync_detailed(project_id=test_project.id, \n",
+    "                              dataset_id=dataset_id,\n",
+    "                              client=cirro.api_client)"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "f7c9bb8a45b9c0e0",
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[FileEntry(path='data/max_intensity_1.svg', size=67051, metadata=FileEntryMetadata(additional_properties={}), additional_properties={}),\n FileEntry(path='data/percent_base.svg', size=85084, metadata=FileEntryMetadata(additional_properties={}), additional_properties={}),\n FileEntry(path='data/run_metrics.html', size=3809, metadata=FileEntryMetadata(additional_properties={}), additional_properties={}),\n FileEntry(path='data/run_metrics.json', size=2360, metadata=FileEntryMetadata(additional_properties={}), additional_properties={})]"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from cirro_api_client.v1.models import DatasetAssetsManifest\n",
+    "from cirro_api_client.v1.api.datasets import get_dataset_manifest\n",
+    "\n",
+    "manifest: DatasetAssetsManifest = get_dataset_manifest.sync(project_id=test_project.id, \n",
+    "                                                            dataset_id=dataset_id,\n",
+    "                                                            client=cirro.api_client)\n",
+    "manifest.files"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-02-21T15:32:41.242435600Z",
+     "start_time": "2024-02-21T15:32:40.985728800Z"
+    }
+   },
+   "id": "1eee7eb53f86fce9",
+   "execution_count": 4
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/samples/Advanced_usage.ipynb
+++ b/samples/Advanced_usage.ipynb
@@ -83,14 +83,11 @@
    "cell_type": "code",
    "outputs": [],
    "source": [
-    "from cirro_api_client.v1.models import SetUserProjectRoleRequest, ProjectRole\n",
+    "from cirro_api_client.v1.models import ProjectRole\n",
     "\n",
-    "set_role_request = SetUserProjectRoleRequest(\n",
-    "    username='cirro@cirro.bio',\n",
-    "    role=ProjectRole.COLLABORATOR\n",
-    ")\n",
     "cirro.projects.set_user_role(project_id=test_project.id,\n",
-    "                             request=set_role_request)"
+    "                             username='cirro@cirro.bio',\n",
+    "                             role=ProjectRole.COLLABORATOR)"
    ],
    "metadata": {
     "collapsed": false,

--- a/samples/Advanced_usage.ipynb
+++ b/samples/Advanced_usage.ipynb
@@ -275,12 +275,13 @@
     "You can access the client by using the `api_client` property on the `Cirro` class.\n",
     "\n",
     "\n",
-    "The API client mirrors the [OpenAPI specification](https://api.dev.cirro.bio/openapi/views/redoc/index.html) of Cirro. It exposes every API endpoint under the syntax: `cirro_api_client.v1.api.<tag> import <endpoint>`. Models are exposed at `cirro_api_client\n",
+    "The API client mirrors the [OpenAPI specification](https://api.dev.cirro.bio/openapi/views/redoc/index.html) of Cirro. It exposes every API endpoint under the syntax: `cirro_api_client.v1.api.<tag> import <endpoint>`. Models are exposed at `cirro_api_client.v1.models`.\n",
+    "\n",
     "Each `tag` corresponds to a group of endpoints, such as datasets, metadata, projects, etc., and the `endpoint` corresponds to an operation.\n",
     "\n",
     "You can read more about the API client [here](https://github.com/CirroBio/Cirro-client-python). \n",
     "\n",
-    "Each endpoint exposes a synchronous (`sync`) and asynchronous (`async`) function depending on if you use the async features in Python. All functions require the `client` parameter. You can pass in the `cirro.api_client` property here."
+    "Each endpoint exposes a synchronous (`sync`) and asynchronous (`async`) function depending on if you use the async features in Python. All functions require you to pass in an instance of the API client (`client` parameter). You can pass in the `cirro.api_client` property here."
    ],
    "metadata": {
     "collapsed": false


### PR DESCRIPTION
- Add example usage on some more advanced operations, such as using the services, and the lower-level API client. 
- Clean up execution service so it returns user-friendly info
- Fix `dataset.run_analysis` on sdk so it returns the new dataset ID like before
- Convert file size to human readable on `DataPortalFile`
- Use `relative_path` for `DataPortalFile.name` so filter method works like before
- Add publishing of API docs to GitHub pages using pdoc.