### PR TITLE
Improve file requirements messaging

### DIFF
--- a/cirro/cli/cli.py
+++ b/cirro/cli/cli.py
@@ -1,6 +1,8 @@
 import click
 
 from cirro.cli import run_ingest, run_download, run_configure, run_list_datasets
+from cirro.cli.controller import handle_error
+from cirro.cli.interactive.utils import InputError
 
 
 def check_required_args(args):
@@ -75,6 +77,8 @@ def configure():
 def main():
     try:
         run()
+    except InputError as e:
+        handle_error(e)
     except KeyboardInterrupt:
         pass
 

--- a/cirro/cli/controller.py
+++ b/cirro/cli/controller.py
@@ -78,7 +78,10 @@ def run_ingest(input_params: UploadArguments, interactive=False):
 
     process = get_item_from_name_or_id(processes, input_params['process'])
     logger.info(f"Validating expected files: {process.name}")
-    cirro.processes.check_dataset_files(process_id=process.id, files=files, directory=directory)
+    try:
+        cirro.processes.check_dataset_files(process_id=process.id, files=files, directory=directory)
+    except ValueError as e:
+        raise InputError(e)
     logger.info("Creating new dataset")
 
     upload_dataset_request = UploadDatasetRequest(

--- a/cirro/cli/interactive/download_args.py
+++ b/cirro/cli/interactive/download_args.py
@@ -4,16 +4,16 @@ from typing import List
 
 from cirro_api_client.v1.models import Dataset, Project
 
-from cirro.models.file import File
 from cirro.cli.interactive.common_args import ask_project
 from cirro.cli.interactive.utils import ask, prompt_wrapper, InputError
 from cirro.cli.models import DownloadArguments
+from cirro.models.file import File
 from cirro.utils import format_date
 
 
 def ask_dataset(datasets: List[Dataset], input_value: str) -> str:
     if len(datasets) == 0:
-        raise RuntimeWarning("No datasets available")
+        raise InputError("No datasets available")
     sorted_datasets = sorted(datasets, key=lambda d: d.created_at, reverse=True)
     dataset_prompt = {
         'type': 'autocomplete',
@@ -99,7 +99,7 @@ def ask_dataset_files_list(files: List[File]) -> List[File]:
         ):
             return ask_dataset_files_list(files)
         else:
-            raise RuntimeWarning("No files selected")
+            raise InputError("No files selected")
     else:
         return selected_files
 
@@ -115,7 +115,7 @@ def ask_dataset_files_glob(files: List[File]) -> List[File]:
         )
 
     if len(selected_files) == 0:
-        raise RuntimeWarning("No files selected")
+        raise InputError("No files selected")
 
     return selected_files
 

--- a/cirro/cli/interactive/upload_args.py
+++ b/cirro/cli/interactive/upload_args.py
@@ -8,7 +8,7 @@ from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.validation import Validator, ValidationError
 
 from cirro.cli.interactive.common_args import ask_project
-from cirro.cli.interactive.utils import ask, prompt_wrapper
+from cirro.cli.interactive.utils import ask, prompt_wrapper, InputError
 from cirro.cli.models import UploadArguments
 from cirro.file_utils import get_files_in_directory, get_files_stats
 
@@ -140,7 +140,7 @@ def ask_dataset_files_glob(files: List[str]) -> List[str]:
         )
 
     if len(selected_files) == 0:
-        raise RuntimeWarning("No files selected")
+        raise InputError("No files selected")
 
     return selected_files
 

--- a/cirro/services/process.py
+++ b/cirro/services/process.py
@@ -83,19 +83,20 @@ class ProcessService(BaseService):
         if error_msg := requirements.error_msg:
             raise ValueError(error_msg)
 
-        # These will be errors for missing files
-        all_errors = [
-            entry.error_msg for entry in requirements.allowed_data_types
-            if entry.error_msg is not None
-        ]
-        patterns = [
-            ' or '.join([
+        errors = [
+            f'{entry.description}: {entry.error_msg}. We accept any of the following naming conventions: \n\t- ' +
+            '\n\t- '.join([
                 e.example_name
                 for e in entry.allowed_patterns
             ])
             for entry in requirements.allowed_data_types
+            if entry.error_msg is not None
         ]
 
-        if len(all_errors) != 0:
-            raise ValueError("Files do not meet dataset type requirements. The expected files are: \n" +
-                             "\n".join(patterns))
+        files_provided = ', '.join(files)
+
+        if len(errors) != 0:
+            raise ValueError(f"The files you have provided are: {files_provided} \n\n"
+                             "They do not meet the dataset requirements. "
+                             "The required file types are: \n" +
+                             "\n".join(errors))

--- a/cirro/services/process.py
+++ b/cirro/services/process.py
@@ -84,7 +84,7 @@ class ProcessService(BaseService):
             raise ValueError(error_msg)
 
         errors = [
-            f'{entry.description}: {entry.error_msg}. We accept any of the following naming conventions: \n\t- ' +
+            f'{entry.description}. {entry.error_msg}. We accept any of the following naming conventions: \n\t- ' +
             '\n\t- '.join([
                 e.example_name
                 for e in entry.allowed_patterns


### PR DESCRIPTION
CI-206

- Display input errors as a message in the console, rather than a stacktrace
- Improve error message when displaying file requirements

```
2024-06-26 12:33:01,018 INFO     [Cirro CLI] Validating expected files: 10X Single-Cell (FASTQ)
2024-06-26 12:33:01,176 ERROR    [Cirro CLI] The files you have provided are: test.fastq 

They do not meet the dataset requirements. The required file types are: 
Paired FASTQs (with associated index reads). At least 2 file(s) required. We accept any of the following naming conventions: 
        - SampleName_S1_L001_R1_001.fastq.gz
        - SampleName_S1_R1_001.fastq.gz

```

