### PR TITLE
Change S3 Client upload implementation to use upload_fileobj

### DIFF
--- a/cirro/file_utils.py
+++ b/cirro/file_utils.py
@@ -110,7 +110,7 @@ def upload_directory(directory: str, files: List[str], s3_client: S3Client, buck
             # Try the upload
             try:
                 s3_client.upload_file(
-                    local_path=local_path,
+                    file_path=local_path,
                     bucket=bucket,
                     key=key
                 )


### PR DESCRIPTION
Change `upload_file` method to accept Path-like objects, rather than only files on the local file system.