### PR TITLE
Refactor file upload methods to accept Path-like objects

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,6 @@ jobs:
           poetry run flake8 cirro
 
       - name: Run Tests
-        working-directory: tests
         run: |
           poetry run pytest --cov --cov-report=xml --cov-branch -o junit_family=xunit2 --junitxml=junit/test-results.xml
 

--- a/cirro/cli/controller.py
+++ b/cirro/cli/controller.py
@@ -98,7 +98,7 @@ def run_ingest(input_params: UploadArguments, interactive=False):
     logger.info("Uploading files")
     cirro.datasets.upload_files(project_id=project_id,
                                 dataset_id=create_resp.id,
-                                local_directory=directory,
+                                directory=directory,
                                 files=files)
 
     if cirro.configuration.enable_additional_checksum:

--- a/cirro/cli/interactive/upload_args.py
+++ b/cirro/cli/interactive/upload_args.py
@@ -71,7 +71,7 @@ def confirm_data_files(data_directory: str, files: List[str]):
 
     if not ask(
         "confirm",
-        f'Please confirm that you wish to upload {stats["numberOfFiles"]} files ({stats["sizeFriendly"]})'
+        f'Please confirm that you wish to upload {stats.number_of_files} files ({stats.size_friendly})'
     ):
         sys.exit(1)
 

--- a/cirro/file_utils.py
+++ b/cirro/file_utils.py
@@ -83,10 +83,10 @@ def get_files_in_directory(
 
 
 def _bytes_to_human_readable(num_bytes: int) -> str:
-    for unit in ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']:
-        if num_bytes < 1024.0 or unit == 'PiB':
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB']:
+        if num_bytes < 1000.0 or unit == 'PB':
             break
-        num_bytes /= 1024.0
+        num_bytes /= 1000.0
     return f"{num_bytes:,.2f} {unit}"
 
 

--- a/cirro/models/file.py
+++ b/cirro/models/file.py
@@ -13,7 +13,7 @@ class DirectoryStatistics(NamedTuple):
     size: float
     " Size in bytes"
     size_friendly: str
-    " Size in GB"
+    " Size in user friendly format (e.g. 1.2 KB)"
     number_of_files: int
     " Number of files"
 

--- a/cirro/models/file.py
+++ b/cirro/models/file.py
@@ -1,16 +1,22 @@
 from dataclasses import dataclass
-from pathlib import PurePath
-from typing import TypedDict, Dict, Optional
+from pathlib import PurePath, Path
+from typing import Dict, Optional, TypeVar, NamedTuple
 
 from cirro_api_client.v1.models import FileAccessRequest, AccessType, FileEntry
+from pathlib_abc import PathBase
 
 from cirro.models.s3_path import S3Path
 
+PathLike = TypeVar('PathLike', str, Path, PathBase)
 
-class DirectoryStatistics(TypedDict):
+
+class DirectoryStatistics(NamedTuple):
     size: float
-    sizeFriendly: str
-    numberOfFiles: int
+    " Size in bytes"
+    size_friendly: str
+    " Size in GB"
+    number_of_files: int
+    " Number of files"
 
 
 class FileAccessContext:

--- a/cirro/models/file.py
+++ b/cirro/models/file.py
@@ -3,11 +3,10 @@ from pathlib import PurePath, Path
 from typing import Dict, Optional, TypeVar, NamedTuple
 
 from cirro_api_client.v1.models import FileAccessRequest, AccessType, FileEntry
-from pathlib_abc import PathBase
 
 from cirro.models.s3_path import S3Path
 
-PathLike = TypeVar('PathLike', str, Path, PathBase)
+PathLike = TypeVar('PathLike', str, Path)
 
 
 class DirectoryStatistics(NamedTuple):

--- a/cirro/sdk/project.py
+++ b/cirro/sdk/project.py
@@ -195,7 +195,7 @@ class DataPortalProject(DataPortalAsset):
         self._client.datasets.upload_files(
             project_id=self.id,
             dataset_id=create_response.id,
-            local_directory=upload_folder,
+            directory=upload_folder,
             files=files
         )
 

--- a/cirro/services/dataset.py
+++ b/cirro/services/dataset.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List, Optional, Union
 
 from cirro_api_client.v1.api.datasets import get_datasets, get_dataset, import_public_dataset, upload_dataset, \
@@ -5,7 +6,7 @@ from cirro_api_client.v1.api.datasets import get_datasets, get_dataset, import_p
 from cirro_api_client.v1.models import ImportDataRequest, UploadDatasetRequest, UpdateDatasetRequest, Dataset, \
     DatasetDetail, CreateResponse, UploadDatasetCreateResponse
 
-from cirro.models.file import FileAccessContext, File
+from cirro.models.file import FileAccessContext, File, PathLike
 from cirro.services.base import get_all_records
 from cirro.services.file import FileEnabledService
 
@@ -166,16 +167,20 @@ class DatasetService(FileEnabledService):
         ]
         return files
 
-    def upload_files(self, project_id: str, dataset_id: str, local_directory: str, files: List[str]) -> None:
+    def upload_files(self,
+                     project_id: str,
+                     dataset_id: str,
+                     directory: PathLike,
+                     files: List[PathLike]) -> None:
         """
-        Uploads files to a given dataset from the specified local directory
+        Uploads files to a given dataset from the specified directory.
 
         Args:
             project_id (str): ID of the Project
             dataset_id (str): ID of the Dataset
-            local_directory (str): Path to local directory
-            files (typing.List[str]): List of relative paths to files within the local directory
-
+            directory (str|Path): Path to directory
+            files (typing.List[str|Path]): List of paths to files within the directory,
+                must be the same type as directory.
         """
         dataset = self.get(project_id, dataset_id)
 
@@ -186,9 +191,9 @@ class DatasetService(FileEnabledService):
         )
 
         self._file_service.upload_files(
-            access_context,
-            local_directory,
-            files
+            access_context=access_context,
+            directory=directory,
+            files=files
         )
 
     def download_files(

--- a/cirro/services/dataset.py
+++ b/cirro/services/dataset.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import List, Optional, Union
 
 from cirro_api_client.v1.api.datasets import get_datasets, get_dataset, import_public_dataset, upload_dataset, \

--- a/cirro/services/file.py
+++ b/cirro/services/file.py
@@ -1,7 +1,6 @@
 import threading
 from datetime import datetime, timezone
 from functools import partial
-from pathlib import Path
 from typing import List, Dict
 
 from cirro_api_client import CirroApiClient

--- a/cirro/services/file.py
+++ b/cirro/services/file.py
@@ -1,6 +1,7 @@
 import threading
 from datetime import datetime, timezone
 from functools import partial
+from pathlib import Path
 from typing import List, Dict
 
 from cirro_api_client import CirroApiClient
@@ -9,7 +10,7 @@ from cirro_api_client.v1.models import AWSCredentials, AccessType
 
 from cirro.clients.s3 import S3Client
 from cirro.file_utils import upload_directory, download_directory
-from cirro.models.file import FileAccessContext, File
+from cirro.models.file import FileAccessContext, File, PathLike
 from cirro.services.base import BaseService
 
 
@@ -126,14 +127,18 @@ class FileService(BaseService):
             bucket=access_context.bucket
         )
 
-    def upload_files(self, access_context: FileAccessContext, directory: str, files: List[str]) -> None:
+    def upload_files(self,
+                     access_context: FileAccessContext,
+                     directory: PathLike,
+                     files: List[PathLike]) -> None:
         """
         Uploads a list of files from the specified directory
 
         Args:
             access_context (cirro.models.file.FileAccessContext): File access context, use class methods to generate
-            directory (str): base path to upload from
-            files (List[str]): relative path of files to upload
+            directory (str|Path): Path to directory
+            files (typing.List[str|Path]): List of paths to files within the directory
+                must be the same type as directory.
         """
 
         s3_client = S3Client(

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=CirroBio_Cirro-client
 sonar.organization=cirrobio
 sonar.python.version=3.9
-sonar.python.xunit.reportPath=tests/junit/test-results.xml
-sonar.python.coverage.reportPaths=tests/coverage.xml
+sonar.python.xunit.reportPath=junit/test-results.xml
+sonar.python.coverage.reportPaths=coverage.xml
 sonar.exclusions=**/tests/*.py

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -13,12 +13,13 @@ class TestFileUtils(unittest.TestCase):
         self.test_prefix = 'datasets/1a1a/data'
 
     def test_get_file_stats(self):
-        files = get_files_in_directory(Path('.'))
-        files = [Path(f) for f in files]
+        directory = Path(__file__).parent / 'data'
+        files = get_files_in_directory(directory)
+        files = [Path(directory, f) for f in files]
         stats = get_files_stats(files=files)
         self.assertGreater(stats.size, 0)
         self.assertGreater(stats.number_of_files, 0)
-        self.assertIn('KiB', stats.size_friendly)
+        self.assertIn('KB', stats.size_friendly)
 
     def test_upload_directory_pathlike(self):
         test_path = Path('/Users/test/Documents/dataset1')

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,74 @@
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, call
+
+from cirro.file_utils import upload_directory, get_files_in_directory, get_files_stats
+
+
+class TestFileUtils(unittest.TestCase):
+    def setUp(self):
+        self.mock_s3_client = Mock()
+        self.mock_s3_client.upload_file = Mock()
+        self.test_bucket = 'project-1a1a'
+        self.test_prefix = 'datasets/1a1a/data'
+
+    def test_get_file_stats(self):
+        files = get_files_in_directory(Path('.'))
+        files = [Path(f) for f in files]
+        stats = get_files_stats(files=files)
+        self.assertGreater(stats.size, 0)
+        self.assertGreater(stats.number_of_files, 0)
+        self.assertIn('KiB', stats.size_friendly)
+
+    def test_upload_directory_pathlike(self):
+        test_path = Path('/Users/test/Documents/dataset1')
+        test_files = [
+            Path('/Users/test/Documents/dataset1/test_file.fastq'),
+            Path('/Users/test/Documents/dataset1/folder1/test_file.fastq'),
+        ]
+        upload_directory(directory=test_path,
+                         files=test_files,
+                         s3_client=self.mock_s3_client,
+                         bucket=self.test_bucket,
+                         prefix=self.test_prefix)
+
+        # The function should upload files relative to the directory path.
+        self.mock_s3_client.upload_file.assert_has_calls([
+            call(file_path=test_files[0], bucket=self.test_bucket, key=f'{self.test_prefix}/test_file.fastq'),
+            call(file_path=test_files[1], bucket=self.test_bucket, key=f'{self.test_prefix}/folder1/test_file.fastq')
+        ], any_order=True)
+
+    def test_upload_directory_string(self):
+        test_path = 'data'
+        test_files = [
+            'file1.txt',
+            'folder1/file2.txt'
+        ]
+        upload_directory(directory=test_path,
+                         files=test_files,
+                         s3_client=self.mock_s3_client,
+                         bucket=self.test_bucket,
+                         prefix=self.test_prefix)
+
+        # The function should upload files relative to the directory path,
+        # but also format file_path into the Path object.
+        self.mock_s3_client.upload_file.assert_has_calls([
+            call(file_path=Path(test_path, test_files[0]),
+                 bucket=self.test_bucket,
+                 key=f'{self.test_prefix}/file1.txt'),
+            call(file_path=Path(test_path, test_files[1]),
+                 bucket=self.test_bucket,
+                 key=f'{self.test_prefix}/folder1/file2.txt')
+        ], any_order=True)
+
+    def test_upload_directory_different_types(self):
+        test_path = Path('s3://bucket/dataset1')
+        test_files = [
+            's3://bucket/dataset1/file2.txt'
+        ]
+        with self.assertRaises(ValueError):
+            upload_directory(directory=test_path,
+                             files=test_files,
+                             s3_client=self.mock_s3_client,
+                             bucket=self.test_bucket,
+                             prefix=self.test_prefix)


### PR DESCRIPTION
CI-211

- Accept Path-like objects on the `upload_file` related functions.
- Add automated test for confirming that it supports object key naming to the correct relative location.
- Add `PathLike` type hint to confirm that both directory and files are the same type.
- Remove reference to "local"
- Improve file size display (so it supports more than GB).
