### PR TITLE
CI-424 - Add support for static access token

### DIFF
--- a/cirro/auth/__init__.py
+++ b/cirro/auth/__init__.py
@@ -1,11 +1,13 @@
 from io import StringIO
 from typing import Optional
 
+from cirro.auth.access_token import AccessTokenAuth
 from cirro.auth.device_code import DeviceCodeAuth
 
 __all__ = [
     'get_auth_info_from_config',
-    "DeviceCodeAuth"
+    "DeviceCodeAuth",
+    "AccessTokenAuth",
 ]
 
 from cirro.config import AppConfig

--- a/cirro/auth/access_token.py
+++ b/cirro/auth/access_token.py
@@ -29,5 +29,5 @@ class AccessTokenAuth(AuthInfo):
     def _update_token_metadata(self):
         decoded_access_token = jwt.decode(self._token,
                                           options={"verify_signature": False})
-        self.access_token_expiry = datetime.fromtimestamp(decoded_access_token['exp'])
+        self._access_token_expiry = datetime.fromtimestamp(decoded_access_token['exp'])
         self._username = decoded_access_token['username']

--- a/cirro/auth/access_token.py
+++ b/cirro/auth/access_token.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+import jwt
+from cirro_api_client import TokenAuth
+from cirro_api_client.cirro_auth import AuthMethod
+
+from cirro.auth.base import AuthInfo
+
+
+class AccessTokenAuth(AuthInfo):
+    """
+    Authenticates to Cirro with a static access token
+
+    :param token: Access token
+    """
+
+    def __init__(self, token: str):
+        self._token = token
+        self._username = None
+        self._access_token_expiry = None
+        self._update_token_metadata()
+
+    def get_current_user(self) -> str:
+        return self._username
+
+    def get_auth_method(self) -> AuthMethod:
+        return TokenAuth(token=self._token)
+
+    def _update_token_metadata(self):
+        decoded_access_token = jwt.decode(self._token,
+                                          options={"verify_signature": False})
+        self.access_token_expiry = datetime.fromtimestamp(decoded_access_token['exp'])
+        self._username = decoded_access_token['username']


### PR DESCRIPTION
Add support for access token auth. 

In cases where another piece of software is responsible for fetching the token.