### PR TITLE
CI-614 - Allow override of destination file names when uploading via SDK

### DIFF
--- a/cirro/clients/s3.py
+++ b/cirro/clients/s3.py
@@ -38,6 +38,9 @@ class S3Client:
         self._upload_args = dict(ChecksumAlgorithm='SHA256') if enable_additional_checksum else dict()
         self._download_args = dict(ChecksumMode='ENABLED') if enable_additional_checksum else dict()
 
+    def get_aws_client(self):
+        return self._client
+
     def upload_file(self, file_path: Path, bucket: str, key: str):
         file_size = file_path.stat().st_size
         file_name = file_path.name

--- a/cirro/file_utils.py
+++ b/cirro/file_utils.py
@@ -35,6 +35,23 @@ def filter_files_by_pattern(files: Union[List[File], List[str]], pattern: str) -
     ]
 
 
+def generate_flattened_file_map(files: List[PathLike]) -> Dict[PathLike, str]:
+    """
+    Generates a mapping of file paths "flattened" to their base name.
+
+    Example:  data1/sample1.fastq.gz -> sample1.fastq.gz
+
+    Args:
+        files: List[PathLike]: List of file paths
+
+    Returns:
+        Dict[PathLike, str]: Mapping of file paths to their base name
+    """
+    return {
+        file : Path(file).name for file in files
+    }
+
+
 def _is_hidden_file(file_path: Path):
     # Remove hidden files from listing, desktop.ini .DS_Store, etc.
     if os.name == 'nt':

--- a/cirro/file_utils.py
+++ b/cirro/file_utils.py
@@ -2,7 +2,7 @@ import os
 import random
 import time
 from pathlib import Path, PurePath
-from typing import List, Union
+from typing import List, Union, Dict
 
 from boto3.exceptions import S3UploadFailedError
 from botocore.exceptions import ConnectionError
@@ -105,6 +105,7 @@ def get_files_stats(files: List[PathLike]) -> DirectoryStatistics:
 
 def upload_directory(directory: PathLike,
                      files: List[PathLike],
+                     file_path_map: Dict[PathLike, PathLike],
                      s3_client: S3Client,
                      bucket: str,
                      prefix: str,
@@ -117,6 +118,7 @@ def upload_directory(directory: PathLike,
         directory (str|Path): Path to directory
         files (typing.List[str|Path]): List of paths to files within the directory
             must be the same type as directory.
+        file_path_map (typing.Dict[str|Path, str|Path]): Map of file paths from source to destination
         s3_client (cirro.clients.S3Client): S3 client
         bucket (str): S3 bucket
         prefix (str): S3 prefix
@@ -132,7 +134,13 @@ def upload_directory(directory: PathLike,
         else:
             file_path = file
 
-        file_relative = file_path.relative_to(directory).as_posix()
+        # Check if is present in the file_path_map
+        # if it is, use the mapped value as the destination path
+        if file in file_path_map:
+            file_relative = file_path_map[file]
+        else:
+            file_relative = file_path.relative_to(directory).as_posix()
+
         key = f'{prefix}/{file_relative}'
         success = False
 

--- a/cirro/file_utils.py
+++ b/cirro/file_utils.py
@@ -105,7 +105,7 @@ def get_files_stats(files: List[PathLike]) -> DirectoryStatistics:
 
 def upload_directory(directory: PathLike,
                      files: List[PathLike],
-                     file_path_map: Dict[PathLike, PathLike],
+                     file_path_map: Dict[PathLike, str],
                      s3_client: S3Client,
                      bucket: str,
                      prefix: str,
@@ -118,7 +118,7 @@ def upload_directory(directory: PathLike,
         directory (str|Path): Path to directory
         files (typing.List[str|Path]): List of paths to files within the directory
             must be the same type as directory.
-        file_path_map (typing.Dict[str|Path, str|Path]): Map of file paths from source to destination
+        file_path_map (typing.Dict[str|Path, str]): Map of file paths from source to destination
         s3_client (cirro.clients.S3Client): S3 client
         bucket (str): S3 bucket
         prefix (str): S3 prefix

--- a/cirro/file_utils.py
+++ b/cirro/file_utils.py
@@ -48,7 +48,7 @@ def generate_flattened_file_map(files: List[PathLike]) -> Dict[PathLike, str]:
         Dict[PathLike, str]: Mapping of file paths to their base name
     """
     return {
-        file : Path(file).name for file in files
+        file: Path(file).name for file in files
     }
 
 

--- a/cirro/services/dataset.py
+++ b/cirro/services/dataset.py
@@ -241,6 +241,7 @@ class DatasetService(FileEnabledService):
              from source path to destination path, used to "re-write" paths within the dataset.
         ```python
         from cirro.cirro_client import CirroApi
+        from cirro.file_utils import generate_flattened_file_map
 
         cirro = CirroApi()
 
@@ -254,15 +255,13 @@ class DatasetService(FileEnabledService):
 
         # Or you could automate the flattening
         files = ["data1/file1.fastq.gz"]
-        file_map = {
-          k : Path(k).name for k in files
-        }
+        file_map = generate_flattened_file_map(files)
 
         cirro.datasets.upload_files(
             project_id="project-id",
             dataset_id="dataset-id",
             directory=directory,
-            files=file_map.keys(),
+            files=list(file_map.keys()),
             file_path_map=file_map
         )
         ```

--- a/cirro/services/dataset.py
+++ b/cirro/services/dataset.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Dict
+from typing import List, Optional, Union
 
 from cirro_api_client.v1.api.datasets import get_datasets, get_dataset, import_public_dataset, upload_dataset, \
     update_dataset, delete_dataset, get_dataset_manifest

--- a/cirro/services/dataset.py
+++ b/cirro/services/dataset.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 from cirro_api_client.v1.api.datasets import get_datasets, get_dataset, import_public_dataset, upload_dataset, \
     update_dataset, delete_dataset, get_dataset_manifest
@@ -222,9 +222,14 @@ class DatasetService(FileEnabledService):
                      project_id: str,
                      dataset_id: str,
                      directory: PathLike,
-                     files: List[PathLike]) -> None:
+                     files: List[PathLike] = None,
+                     file_path_map=None) -> None:
         """
         Uploads files to a given dataset from the specified directory.
+
+        All files must be relative to the specified directory.
+        If files need to be flattened, or you are sourcing files from multiple directories,
+        please include `file_path_map` or call this method multiple times.
 
         Args:
             project_id (str): ID of the Project
@@ -232,7 +237,12 @@ class DatasetService(FileEnabledService):
             directory (str|Path): Path to directory
             files (typing.List[str|Path]): List of paths to files within the directory,
                 must be the same type as directory.
+            file_path_map (typing.Dict[str|Path, str|Path]): Optional mapping of file paths to upload
+             from source path to destination path, used to "re-write" paths within the dataset.
         """
+        if file_path_map is None:
+            file_path_map = {}
+
         dataset = self.get(project_id, dataset_id)
 
         access_context = FileAccessContext.upload_dataset(
@@ -244,7 +254,8 @@ class DatasetService(FileEnabledService):
         self._file_service.upload_files(
             access_context=access_context,
             directory=directory,
-            files=files
+            files=files,
+            file_path_map=file_path_map
         )
 
     def download_files(

--- a/cirro/services/dataset.py
+++ b/cirro/services/dataset.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 from cirro_api_client.v1.api.datasets import get_datasets, get_dataset, import_public_dataset, upload_dataset, \
     update_dataset, delete_dataset, get_dataset_manifest
@@ -223,7 +223,7 @@ class DatasetService(FileEnabledService):
                      dataset_id: str,
                      directory: PathLike,
                      files: List[PathLike] = None,
-                     file_path_map=None) -> None:
+                     file_path_map: Dict[PathLike, str]=None) -> None:
         """
         Uploads files to a given dataset from the specified directory.
 
@@ -239,6 +239,33 @@ class DatasetService(FileEnabledService):
                 must be the same type as directory.
             file_path_map (typing.Dict[str|Path, str|Path]): Optional mapping of file paths to upload
              from source path to destination path, used to "re-write" paths within the dataset.
+        ```python
+        from cirro.cirro_client import CirroApi
+
+        cirro = CirroApi()
+
+        directory = "~/Downloads"
+        # Re-write file paths
+        file_map = {
+            "data1/file1.fastq.gz": "file1.fastq.gz",
+            "data2/file2.fastq.gz": "file2.fastq.gz",
+            "file3.fastq.gz": "new_file3.txt"
+        }
+
+        # Or you could automate the flattening
+        files = ["data1/file1.fastq.gz"]
+        file_map = {
+          k : Path(k).name for k in files
+        }
+
+        cirro.datasets.upload_files(
+            project_id="project-id",
+            dataset_id="dataset-id",
+            directory=directory,
+            files=file_map.keys(),
+            file_path_map=file_map
+        )
+        ```
         """
         if file_path_map is None:
             file_path_map = {}

--- a/cirro/services/dataset.py
+++ b/cirro/services/dataset.py
@@ -223,7 +223,7 @@ class DatasetService(FileEnabledService):
                      dataset_id: str,
                      directory: PathLike,
                      files: List[PathLike] = None,
-                     file_path_map: Dict[PathLike, str]=None) -> None:
+                     file_path_map: Dict[PathLike, str] = None) -> None:
         """
         Uploads files to a given dataset from the specified directory.
 

--- a/cirro/services/file.py
+++ b/cirro/services/file.py
@@ -76,7 +76,7 @@ class FileService(BaseService):
 
         This is seeded with refreshable credentials from the access_context parameter
 
-        This may be used to perform advanced operations, such as
+        This may be used to perform advanced operations, such as CopyObject, S3 Select, etc.
         """
         s3_client = self._generate_s3_client(access_context)
         return s3_client.get_aws_client()

--- a/cirro/services/file.py
+++ b/cirro/services/file.py
@@ -134,7 +134,7 @@ class FileService(BaseService):
                      access_context: FileAccessContext,
                      directory: PathLike,
                      files: List[PathLike],
-                     file_path_map: Dict[PathLike, PathLike]) -> None:
+                     file_path_map: Dict[PathLike, str]) -> None:
         """
         Uploads a list of files from the specified directory
 
@@ -143,7 +143,7 @@ class FileService(BaseService):
             directory (str|Path): Path to directory
             files (typing.List[str|Path]): List of paths to files within the directory
                 must be the same type as directory.
-            file_path_map (typing.Dict[str|Path, str|Path]): Optional mapping of file paths to upload
+            file_path_map (typing.Dict[str|Path, str]): Optional mapping of file paths to upload
              from source path to destination path, used to "re-write" paths within the dataset.
         """
         s3_client = self._generate_s3_client(access_context)

--- a/cirro/services/file.py
+++ b/cirro/services/file.py
@@ -133,7 +133,8 @@ class FileService(BaseService):
     def upload_files(self,
                      access_context: FileAccessContext,
                      directory: PathLike,
-                     files: List[PathLike]) -> None:
+                     files: List[PathLike],
+                     file_path_map: Dict[PathLike, PathLike]) -> None:
         """
         Uploads a list of files from the specified directory
 
@@ -142,15 +143,18 @@ class FileService(BaseService):
             directory (str|Path): Path to directory
             files (typing.List[str|Path]): List of paths to files within the directory
                 must be the same type as directory.
+            file_path_map (typing.Dict[str|Path, str|Path]): Optional mapping of file paths to upload
+             from source path to destination path, used to "re-write" paths within the dataset.
         """
         s3_client = self._generate_s3_client(access_context)
 
         upload_directory(
-            directory,
-            files,
-            s3_client,
-            access_context.bucket,
-            access_context.prefix,
+            directory=directory,
+            files=files,
+            file_path_map=file_path_map,
+            s3_client=s3_client,
+            bucket=access_context.bucket,
+            prefix=access_context.prefix,
             max_retries=self.transfer_retries
         )
 

--- a/cirro/services/file.py
+++ b/cirro/services/file.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from functools import partial
 from typing import List, Dict
 
+from botocore.client import BaseClient
 from cirro_api_client import CirroApiClient
 from cirro_api_client.v1.api.file import generate_project_file_access_token
 from cirro_api_client.v1.models import AWSCredentials, ProjectAccessType
@@ -69,6 +70,17 @@ class FileService(BaseService):
 
         return self._read_token_cache[project_id]
 
+    def get_aws_s3_client(self, access_context: FileAccessContext) -> BaseClient:
+        """
+        Gets the underlying AWS S3 client to perform operations on files
+
+        This is seeded with refreshable credentials from the access_context parameter
+
+        This may be used to perform advanced operations, such as
+        """
+        s3_client = self._generate_s3_client(access_context)
+        return s3_client.get_aws_client()
+
     def get_file(self, file: File) -> bytes:
         """
         Gets the contents of a file
@@ -92,11 +104,7 @@ class FileService(BaseService):
         Returns:
             The raw bytes of the file
         """
-
-        s3_client = S3Client(
-            partial(self.get_access_credentials, access_context),
-            self.enable_additional_checksum
-        )
+        s3_client = self._generate_s3_client(access_context)
 
         full_path = f'{access_context.prefix}/{file_path}'.lstrip('/')
 
@@ -113,11 +121,7 @@ class FileService(BaseService):
             contents (str): Content of object
             content_type (str):
         """
-
-        s3_client = S3Client(
-            partial(self.get_access_credentials, access_context),
-            self.enable_additional_checksum
-        )
+        s3_client = self._generate_s3_client(access_context)
 
         s3_client.create_object(
             key=key,
@@ -139,11 +143,7 @@ class FileService(BaseService):
             files (typing.List[str|Path]): List of paths to files within the directory
                 must be the same type as directory.
         """
-
-        s3_client = S3Client(
-            partial(self.get_access_credentials, access_context),
-            self.enable_additional_checksum
-        )
+        s3_client = self._generate_s3_client(access_context)
 
         upload_directory(
             directory,
@@ -163,10 +163,7 @@ class FileService(BaseService):
             directory (str): download location
             files (List[str]): relative path of files to download
         """
-        s3_client = S3Client(
-            partial(self.get_access_credentials, access_context),
-            self.enable_additional_checksum
-        )
+        s3_client = self._generate_s3_client(access_context)
 
         download_directory(
             directory,
@@ -174,6 +171,15 @@ class FileService(BaseService):
             s3_client,
             access_context.bucket,
             access_context.prefix
+        )
+
+    def _generate_s3_client(self, access_context: FileAccessContext):
+        """
+        Generates the Cirro-S3 client to perform operations on files
+        """
+        return S3Client(
+            partial(self.get_access_credentials, access_context),
+            self.enable_additional_checksum
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cirro"
-version = "1.5.0"
+version = "1.5.1"
 description = "CLI tool and SDK for interacting with the Cirro platform"
 authors = ["Cirro Bio <support@cirro.bio>"]
 license = "MIT"

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -29,6 +29,7 @@ class TestFileUtils(unittest.TestCase):
         ]
         upload_directory(directory=test_path,
                          files=test_files,
+                         file_path_map={},
                          s3_client=self.mock_s3_client,
                          bucket=self.test_bucket,
                          prefix=self.test_prefix)
@@ -47,6 +48,7 @@ class TestFileUtils(unittest.TestCase):
         ]
         upload_directory(directory=test_path,
                          files=test_files,
+                         file_path_map={},
                          s3_client=self.mock_s3_client,
                          bucket=self.test_bucket,
                          prefix=self.test_prefix)
@@ -70,6 +72,36 @@ class TestFileUtils(unittest.TestCase):
         with self.assertRaises(ValueError):
             upload_directory(directory=test_path,
                              files=test_files,
+                             file_path_map={},
                              s3_client=self.mock_s3_client,
                              bucket=self.test_bucket,
                              prefix=self.test_prefix)
+
+    def test_upload_directory_file_map_included(self):
+        test_path = 'data'
+        test_files = [
+            'file1.txt',
+            'folder1/file2.txt'
+        ]
+
+        file_path_map = {
+            'file1.txt': 'mapped_file1.txt',
+            'folder1/file2.txt': 'mapped_file2.txt'
+        }
+
+        upload_directory(directory=test_path,
+                         files=test_files,
+                         file_path_map=file_path_map,
+                         s3_client=self.mock_s3_client,
+                         bucket=self.test_bucket,
+                         prefix=self.test_prefix)
+
+        # Check that upload file was called with the mapped key
+        self.mock_s3_client.upload_file.assert_has_calls([
+            call(file_path=Path(test_path, test_files[0]),
+                 bucket=self.test_bucket,
+                 key=f'{self.test_prefix}/mapped_file1.txt'),
+            call(file_path=Path(test_path, test_files[1]),
+                 bucket=self.test_bucket,
+                 key=f'{self.test_prefix}/mapped_file2.txt')
+        ], any_order=True)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -81,12 +81,14 @@ class TestFileUtils(unittest.TestCase):
         test_path = 'data'
         test_files = [
             'file1.txt',
-            'folder1/file2.txt'
+            'folder1/file2.txt',
+            'folder1/unmapped.txt'
         ]
 
         file_path_map = {
             'file1.txt': 'mapped_file1.txt',
             'folder1/file2.txt': 'mapped_file2.txt'
+            # unmapped file3
         }
 
         upload_directory(directory=test_path,
@@ -103,5 +105,8 @@ class TestFileUtils(unittest.TestCase):
                  key=f'{self.test_prefix}/mapped_file1.txt'),
             call(file_path=Path(test_path, test_files[1]),
                  bucket=self.test_bucket,
-                 key=f'{self.test_prefix}/mapped_file2.txt')
+                 key=f'{self.test_prefix}/mapped_file2.txt'),
+            call(file_path=Path(test_path, test_files[2]),
+                 bucket=self.test_bucket,
+                 key=f'{self.test_prefix}/folder1/unmapped.txt')
         ], any_order=True)


### PR DESCRIPTION
CI-614

Allow specifying a `file_path_map` when calling the `dataset.upload_files` method.


For example, in this example the file paths are rewritten with "data1" removed.

```
file_path_map = {
    "data1/file1.fastq.gz": "file1.fastq.gz",
    "data2/file2.fastq.gz": "file2.fastq.gz",
    "file3.fastq.gz": "new_file3.txt"
}
```


