### PR TITLE
Add attribute to ParameterSpecification to get json schema representation 

### DIFF
--- a/cirro/models/form_specification.py
+++ b/cirro/models/form_specification.py
@@ -28,6 +28,13 @@ class ParameterSpecification:
         self._form_spec_ui: Dict = form_schema.ui.additional_properties
         self.form_spec = _get_fields_in_schema(self._form_spec_raw.get('properties') or {})
 
+    @property
+    def form_spec_json(self) -> dict:
+        """
+        Returns the JSON schema of the form specification
+        """
+        return self._form_spec_raw
+
     def validate_params(self, params: Dict):
         """
         Validates that the given parameters conforms to the specification


### PR DESCRIPTION
So the user can get the JSON Schema value if they want.