### PR TITLE
CI-1178 - Fix Cirro SDK Token File Error Auth Issue

### DIFF
--- a/cirro/auth/device_code.py
+++ b/cirro/auth/device_code.py
@@ -236,7 +236,13 @@ class DeviceCodeAuth(AuthInfo):
         if not self._persistence or not self._token_path.exists():
             return None
 
-        token_info = json.loads(self._persistence.load())
+        try:
+            token_info = json.loads(self._persistence.load())
+        except (json.JSONDecodeError, ValueError):
+            logger.debug('Saved token file is empty or invalid, clearing it')
+            self._clear_token_info()
+            return None
+
         if 'access_token' not in token_info:
             return None
 


### PR DESCRIPTION
When the token file is empty or invalid catch the JSONDecodeError and clear cached credentials so user will just be prompted to log in again.